### PR TITLE
log bans automatically

### DIFF
--- a/commands/ban.js
+++ b/commands/ban.js
@@ -34,37 +34,6 @@ module.exports = {
 			reason: reason ?? `Contact ${author.user.username}#${author.user.discriminator} (${author.user.id}) for details.`,
 		});
 
-		// Await sending the log message so if it fails for some reason we can avoid trying to send two `interaction.reply`s
-		await interaction.client.channels.cache
-			.get(channels.log.ban.id)
-			.send({
-				embeds: [
-					{
-						color: 0xed1515,
-						author: {
-							name: `${author.user.username}#${author.user.discriminator} (${author.user.id})`,
-							icon_url: author.user.displayAvatarURL(),
-						},
-						description: [
-							`**User**: \`${target.username}#${target.discriminator}\` (<@${target.id}>)`,
-							`**Action**: Ban`,
-							`**Reason**: ${reason ?? `Contact <@${user.id}> for details.`}`,
-						].join("\n"),
-						timestamp: new Date(),
-					},
-				],
-			})
-			.catch((error) => {
-				console.error(error);
-				return interaction.reply(
-					`User successfully banned, but something went wrong! Am I allowed to send messages in the channel used for logging bans? \`${error}\``
-				);
-			});
-
-		if (interaction.replied === true) {
-			return;
-		}
-
 		interaction.reply("User successfully banned!");
 	},
 };

--- a/events/guildBanAdd.js
+++ b/events/guildBanAdd.js
@@ -1,0 +1,80 @@
+const { channels } = require("../config.json");
+
+module.exports = {
+	name: "guildBanAdd",
+	async execute(ban, client) {
+		const banLogChannel = client.channels.cache.get(channels.log.ban.id);
+
+		const fetchedLogs = await ban.guild.fetchAuditLogs({
+			limit: 1,
+			type: "MEMBER_BAN_ADD",
+		});
+		// Since there's only 1 audit log entry in this collection, grab the first one
+		const banLog = fetchedLogs.entries.first();
+
+		console.log(banLog, banLog.createdAt, banLog.createdTimestamp);
+
+		// Perform a coherence check to make sure that there's *something*
+		if (!banLog) {
+			banLogChannel
+				.send({
+					embeds: [
+						{
+							color: 0xed1515,
+							description: [
+								`Most details about this ban are unknown, contact a moderator for more information.`,
+								`**Target**: \`${ban.user.username}#${ban.user.discriminator}\` (<@${ban.user.id}>)`,
+								`**Action**: Ban`,
+							].join("\n"),
+						},
+					],
+				})
+				.catch((error) => console.error(error));
+
+			return;
+		}
+
+		// Now grab the user object of the person who banned the member
+		// Also grab the target of this action to double-check things
+		const { reason, executor, target } = banLog;
+
+		// Update the output with a bit more information
+		// Also run a check to make sure that the log returned was for the same banned member
+		if (target.id === ban.user.id) {
+			banLogChannel
+				.send({
+					embeds: [
+						{
+							color: 0xed1515,
+							author: {
+								name: `${executor.username}#${executor.discriminator} (${executor.id})`,
+								icon_url: executor.displayAvatarURL(),
+							},
+							description: [
+								`**User**: \`${target.username}#${target.discriminator}\` (<@${target.id}>)`,
+								`**Action**: Ban`,
+								`**Reason**: ${reason ?? `Contact <@${user.id}> for details.`}`,
+							].join("\n"),
+							timestamp: banLog.createdAt,
+						},
+					],
+				})
+				.catch((error) => console.error(error));
+		} else {
+			banLogChannel
+				.send({
+					embeds: [
+						{
+							color: 0xed1515,
+							description: [
+								`Most details about this ban are unknown, contact a moderator for more information.`,
+								`**Target**: \`${ban.user.username}#${ban.user.discriminator}\` (<@${ban.user.id}>)`,
+								`**Action**: Ban`,
+							].join("\n"),
+						},
+					],
+				})
+				.catch((error) => console.error(error));
+		}
+	},
+};

--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@ const { Client, Collection, Intents } = require("discord.js");
 const { bot } = require("./config.json");
 
 const client = new Client({
-	intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MESSAGE_REACTIONS],
+	intents: [
+		Intents.FLAGS.GUILDS,
+		Intents.FLAGS.GUILD_MEMBERS,
+		Intents.FLAGS.GUILD_MESSAGES,
+		Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+		Intents.FLAGS.GUILD_BANS,
+	],
 	partials: ["MESSAGE", "REACTION"],
 });
 client.commands = new Collection();
@@ -20,9 +26,13 @@ const eventFiles = fs.readdirSync("./events").filter((file) => file.endsWith(".j
 for (const file of eventFiles) {
 	const event = require(`./events/${file}`);
 	if (event.once) {
+		console.log(event.name);
 		client.once(event.name, async (...args) => event.execute(...args, client));
 	} else {
-		client.on(event.name, async (...args) => event.execute(...args, client));
+		client.on(event.name, async (...args) => {
+			console.log(event.name);
+			return event.execute(...args, client);
+		});
 	}
 }
 


### PR DESCRIPTION
Use the audit log to automatically log all bans instead of relying on
moderators to use the ban command.